### PR TITLE
adding an option to command line interface to enable running the code…

### DIFF
--- a/mtcnn_demo.py
+++ b/mtcnn_demo.py
@@ -1,6 +1,11 @@
 # remove tensorflow messages and deprecation from mtcnn packages
-import tensorflow as tf
 import os
+import sys
+
+if len(sys.argv) > 1 and sys.argv[1] == '--cpu':
+    os.environ["CUDA_VISIBLE_DEVICES"] = '-1'
+
+import tensorflow as tf
 tf.logging.set_verbosity(tf.logging.ERROR)
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 ################################################################


### PR DESCRIPTION
… on cpu

Hi there, 

I am not sure how exactly you wish to give users such an option, but I guess most of the time people run such code via command line interface. So I added an option "--cpu". If you run the code "python -m mtcnn_demo --cpu" then it will run on cpu. Otherwise it will run on GPU is it exists.